### PR TITLE
Separate page cache and page cursor tracer.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,11 +15,11 @@ Add the following to `neo4j-wrapper.conf`:
 
 [source]
 ----
-wrapper.java.additional=-XX:+UnlockCommercialFeatures
-wrapper.java.additional=-XX:+FlightRecorder
-wrapper.java.additional=-XX:FlightRecorderOptions=stackdepth=500
-wrapper.java.additional=-XX:+UnlockDiagnosticVMOptions
-wrapper.java.additional=-XX:+DebugNonSafepoints
+dbms.jvm.additional=-XX:+UnlockCommercialFeatures
+dbms.jvm.additional=-XX:+FlightRecorder
+dbms.jvm.additional=-XX:FlightRecorderOptions=stackdepth=500
+dbms.jvm.additional=-XX:+UnlockDiagnosticVMOptions
+dbms.jvm.additional=-XX:+DebugNonSafepoints
 ----
 
 Note that this requires an Oracle JDK, and that there are special licensing terms for FlightRecorder.
@@ -30,7 +30,7 @@ Add the following to your `neo4j.properties` file:
 
 [source]
 ----
-dbms.tracer=jfr
+unsupported.dbms.tracer=jfr
 ----
 
 Neo4j will now report page cache and transaction events to FlightRecorder, next time it starts.

--- a/configuration/src/main/java/org/neo4j/jfr/configuration/ManifestWriter.java
+++ b/configuration/src/main/java/org/neo4j/jfr/configuration/ManifestWriter.java
@@ -19,7 +19,8 @@
  */
 package org.neo4j.jfr.configuration;
 
-import static java.lang.String.format;
+import com.oracle.jrockit.jfr.EventDefinition;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -32,7 +33,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -41,11 +41,10 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
-import com.oracle.jrockit.jfr.EventDefinition;
-import org.apache.commons.lang3.StringUtils;
+import static java.lang.String.format;
 
 @SupportedAnnotationTypes({"org.neo4j.jfr.configuration.Tracer", "com.oracle.jrockit.jfr.EventDefinition"})
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class ManifestWriter extends AbstractProcessor
 {
     private static final String PATH_KEY = "MANIFEST_PATH";

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
   <properties>
     <neo4j.version>${project.version}</neo4j.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <year>${maven.build.timestamp}</year>
     <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
   </properties>

--- a/tracers/src/main/java/org/neo4j/io/pagecache/tracing/jfr/JfrPageCursorTracer.java
+++ b/tracers/src/main/java/org/neo4j/io/pagecache/tracing/jfr/JfrPageCursorTracer.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.tracing.jfr;
+
+import org.neo4j.io.pagecache.PageSwapper;
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.io.pagecache.tracing.PinEvent;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
+
+public class JfrPageCursorTracer implements PageCursorTracer
+{
+
+    private volatile PinEventStarter pinEventStarter = new PinEventStarter();
+
+    @Override
+    public PinEvent beginPin( boolean exclusiveLock, long filePageId, PageSwapper swapper )
+    {
+        return pinEventStarter.startPin( exclusiveLock, filePageId, swapper );
+    }
+
+    @Override
+    public void init( PageCacheTracer tracer )
+    {
+        pinEventStarter = ((JfrPageCacheTracer) tracer).getPinEventStarter();
+    }
+
+    @Override
+    public void reportEvents()
+    {
+    }
+
+    @Override
+    public long faults()
+    {
+        return 0;
+    }
+
+    @Override
+    public long pins()
+    {
+        return 0;
+    }
+
+    @Override
+    public long unpins()
+    {
+        return 0;
+    }
+
+    @Override
+    public long hits()
+    {
+        return 0;
+    }
+
+    @Override
+    public long bytesRead()
+    {
+        return 0;
+    }
+
+    @Override
+    public long evictions()
+    {
+        return 0;
+    }
+
+    @Override
+    public long evictionExceptions()
+    {
+        return 0;
+    }
+
+    @Override
+    public long bytesWritten()
+    {
+        return 0;
+    }
+
+    @Override
+    public long flushes()
+    {
+        return 0;
+    }
+}

--- a/tracers/src/main/java/org/neo4j/io/pagecache/tracing/jfr/JfrPageCursorTracerSupplier.java
+++ b/tracers/src/main/java/org/neo4j/io/pagecache/tracing/jfr/JfrPageCursorTracerSupplier.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.tracing.jfr;
+
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
+
+public class JfrPageCursorTracerSupplier implements PageCursorTracerSupplier
+{
+
+    private ThreadLocal<JfrPageCursorTracer> tracer = ThreadLocal.withInitial( JfrPageCursorTracer::new );
+
+    public static final JfrPageCursorTracerSupplier INSTANCE = new JfrPageCursorTracerSupplier();
+
+    private JfrPageCursorTracerSupplier()
+    {
+    }
+
+    public PageCursorTracer get()
+    {
+        return tracer.get();
+    }
+}

--- a/tracers/src/main/java/org/neo4j/io/pagecache/tracing/jfr/JfrPinEvent.java
+++ b/tracers/src/main/java/org/neo4j/io/pagecache/tracing/jfr/JfrPinEvent.java
@@ -34,6 +34,7 @@ public class JfrPinEvent extends TimedEvent implements PinEvent
     static final String REL_KEY_PIN_EVENT_ID = "http://neo4j.com/jfr/pinId";
 
     private final AtomicLong unpins;
+    private final AtomicLong hits;
     private final AtomicLong faults;
     private final AtomicLong bytesRead;
     private final EvictionEventStarter evictionEventStarter;
@@ -54,11 +55,13 @@ public class JfrPinEvent extends TimedEvent implements PinEvent
     public JfrPinEvent(
             AtomicLong unpins,
             AtomicLong faults,
+            AtomicLong hits,
             AtomicLong bytesRead,
             EvictionEventStarter evictionEventStarter )
     {
         super( JfrPageCacheTracer.pinToken );
         this.unpins = unpins;
+        this.hits = hits;
         this.faults = faults;
         this.bytesRead = bytesRead;
         this.evictionEventStarter = evictionEventStarter;
@@ -82,6 +85,12 @@ public class JfrPinEvent extends TimedEvent implements PinEvent
         event.setFilename( filename );
         event.begin();
         return event;
+    }
+
+    @Override
+    public void hit()
+    {
+        hits.getAndIncrement();
     }
 
     public void setPinEventId( long pinEventId )

--- a/tracers/src/main/java/org/neo4j/io/pagecache/tracing/jfr/PinEventStarter.java
+++ b/tracers/src/main/java/org/neo4j/io/pagecache/tracing/jfr/PinEventStarter.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.tracing.jfr;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.io.pagecache.PageSwapper;
+import org.neo4j.io.pagecache.tracing.PinEvent;
+
+class PinEventStarter
+{
+    private final AtomicLong pins;
+    private final AtomicLong unpins;
+    private final AtomicLong hits;
+    private final AtomicLong faults;
+    private final AtomicLong bytesRead;
+    private final EvictionEventStarter evictionEventStarter;
+
+    PinEventStarter()
+    {
+        this( new AtomicLong(), new AtomicLong(), new AtomicLong(), new AtomicLong(), new AtomicLong(),
+                new EvictionEventStarter( new AtomicLong(), new AtomicLong(), new AtomicLong(), new AtomicLong() ) );
+    }
+
+    PinEventStarter( AtomicLong pins, AtomicLong unpins, AtomicLong hits, AtomicLong faults, AtomicLong bytesRead,
+            EvictionEventStarter evictionEventStarter )
+    {
+        this.pins = pins;
+        this.unpins = unpins;
+        this.faults = faults;
+        this.hits = hits;
+        this.bytesRead = bytesRead;
+        this.evictionEventStarter = evictionEventStarter;
+    }
+
+    PinEvent startPin( boolean exclusiveLock, long filePageId, PageSwapper swapper )
+    {
+        long pinEventId = pins.incrementAndGet();
+
+        JfrPinEvent event = new JfrPinEvent( unpins, faults, hits, bytesRead, evictionEventStarter );
+        event.begin();
+        event.setPinEventId( pinEventId );
+        event.setExclusiveLock( exclusiveLock );
+        event.setFilePageId( filePageId );
+        event.setFilename( swapper.file().getName() );
+        return event;
+    }
+}

--- a/tracers/src/main/java/org/neo4j/kernel/monitoring/tracing/jfr/JfrTracerFactory.java
+++ b/tracers/src/main/java/org/neo4j/kernel/monitoring/tracing/jfr/JfrTracerFactory.java
@@ -20,7 +20,9 @@
 package org.neo4j.kernel.monitoring.tracing.jfr;
 
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.io.pagecache.tracing.jfr.JfrPageCacheTracer;
+import org.neo4j.io.pagecache.tracing.jfr.JfrPageCursorTracerSupplier;
 import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -63,5 +65,11 @@ public class JfrTracerFactory implements TracerFactory
         // TODO: reenable when working
         // return tracer;
         return CheckPointTracer.NULL;
+    }
+
+    @Override
+    public PageCursorTracerSupplier createPageCursorTracerSupplier( Monitors monitors, JobScheduler jobScheduler )
+    {
+        return JfrPageCursorTracerSupplier.INSTANCE;
     }
 }

--- a/tracers/src/test/java/org/neo4j/io/pagecache/tracing/jfr/JfrPageCacheTracerTest.java
+++ b/tracers/src/test/java/org/neo4j/io/pagecache/tracing/jfr/JfrPageCacheTracerTest.java
@@ -19,17 +19,117 @@
  */
 package org.neo4j.io.pagecache.tracing.jfr;
 
-import org.neo4j.io.pagecache.tracing.PageCacheTracer;
-import org.neo4j.io.pagecache.tracing.PageCacheTracerTest;
-import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
-import org.neo4j.kernel.monitoring.Monitors;
-import org.neo4j.kernel.monitoring.tracing.jfr.JfrTracerFactory;
+import org.junit.Before;
+import org.junit.Test;
 
-public class JfrPageCacheTracerTest extends PageCacheTracerTest
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageSwapper;
+import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracerTest;
+import org.neo4j.io.pagecache.tracing.DummyPageSwapper;
+import org.neo4j.io.pagecache.tracing.EvictionEvent;
+import org.neo4j.io.pagecache.tracing.EvictionRunEvent;
+import org.neo4j.io.pagecache.tracing.FlushEvent;
+import org.neo4j.io.pagecache.tracing.MajorFlushEvent;
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class JfrPageCacheTracerTest extends DefaultPageCacheTracerTest
 {
-    @Override
-    protected PageCacheTracer createTracer()
+    private PageCacheTracer tracer;
+    private PageSwapper swapper;
+
+    @Before
+    public void setUp()
     {
-        return new JfrTracerFactory().createPageCacheTracer( new Monitors(), new Neo4jJobScheduler() );
+        tracer = new JfrPageCacheTracer();
+        swapper = new DummyPageSwapper( "filename" );
+    }
+
+    @Test
+    public void mustCountEvictions()
+    {
+        try ( EvictionRunEvent evictionRunEvent = tracer.beginPageEvictions( 2 ) )
+        {
+            try ( EvictionEvent evictionEvent = evictionRunEvent.beginEviction() )
+            {
+                FlushEvent flushEvent = evictionEvent.flushEventOpportunity().beginFlush( 0, 0, swapper );
+                flushEvent.addBytesWritten( 12 );
+                flushEvent.done();
+            }
+
+            try ( EvictionEvent evictionEvent = evictionRunEvent.beginEviction() )
+            {
+                FlushEvent flushEvent = evictionEvent.flushEventOpportunity().beginFlush( 0, 0, swapper );
+                flushEvent.addBytesWritten( 12 );
+                flushEvent.done();
+                evictionEvent.threwException( new IOException() );
+            }
+
+            try ( EvictionEvent evictionEvent = evictionRunEvent.beginEviction() )
+            {
+                FlushEvent flushEvent = evictionEvent.flushEventOpportunity().beginFlush( 0, 0, swapper );
+                flushEvent.addBytesWritten( 12 );
+                flushEvent.done();
+                evictionEvent.threwException( new IOException() );
+            }
+
+            evictionRunEvent.beginEviction().close();
+        }
+
+        assertCounts( 0, 0, 0, 0, 4, 2, 3, 0, 36, 0, 0 );
+    }
+
+    @Test
+    public void mustCountFileMappingAndUnmapping()
+    {
+        tracer.mappedFile( new File( "a" ) );
+
+        assertCounts( 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0 );
+
+        tracer.unmappedFile( new File( "a" ) );
+
+        assertCounts( 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1 );
+    }
+
+    @Test
+    public void mustCountFlushes()
+    {
+        try ( MajorFlushEvent cacheFlush = tracer.beginCacheFlush() )
+        {
+            cacheFlush.flushEventOpportunity().beginFlush( 0, 0, swapper ).done();
+            cacheFlush.flushEventOpportunity().beginFlush( 0, 0, swapper ).done();
+            cacheFlush.flushEventOpportunity().beginFlush( 0, 0, swapper ).done();
+        }
+
+        assertCounts( 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0 );
+
+        try ( MajorFlushEvent fileFlush = tracer.beginFileFlush( swapper ) )
+        {
+            fileFlush.flushEventOpportunity().beginFlush( 0, 0, swapper ).done();
+            fileFlush.flushEventOpportunity().beginFlush( 0, 0, swapper ).done();
+            fileFlush.flushEventOpportunity().beginFlush( 0, 0, swapper ).done();
+        }
+
+        assertCounts( 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0 );
+    }
+
+    private void assertCounts( long pins, long unpins, long hits, long faults, long evictions, long evictionExceptions,
+            long flushes, long bytesRead, long bytesWritten, long filesMapped, long filesUnmapped )
+    {
+        assertThat( "pins", tracer.pins(), is( pins ) );
+        assertThat( "unpins", tracer.unpins(), is( unpins ) );
+        assertThat( "hits", tracer.hits(), is( hits ) );
+        assertThat( "faults", tracer.faults(), is( faults ) );
+        assertThat( "evictions", tracer.evictions(), is( evictions ) );
+        assertThat( "evictionExceptions", tracer.evictionExceptions(), is( evictionExceptions ) );
+        assertThat( "flushes", tracer.flushes(), is( flushes ) );
+        assertThat( "bytesRead", tracer.bytesRead(), is( bytesRead ) );
+        assertThat( "bytesWritten", tracer.bytesWritten(), is( bytesWritten ) );
+        assertThat( "filesMapped", tracer.filesMapped(), is( filesMapped ) );
+        assertThat( "filesUnmapped", tracer.filesUnmapped(), is( filesUnmapped ) );
     }
 }

--- a/tracers/src/test/java/org/neo4j/io/pagecache/tracing/jfr/JfrPageCursorTracerTest.java
+++ b/tracers/src/test/java/org/neo4j/io/pagecache/tracing/jfr/JfrPageCursorTracerTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.tracing.jfr;
+
+import org.junit.Test;
+
+import org.neo4j.io.pagecache.tracing.DummyPageSwapper;
+import org.neo4j.io.pagecache.tracing.EvictionEvent;
+import org.neo4j.io.pagecache.tracing.PageFaultEvent;
+import org.neo4j.io.pagecache.tracing.PinEvent;
+
+import static org.junit.Assert.assertEquals;
+
+public class JfrPageCursorTracerTest
+{
+    @Test
+    public void pageCacheTracerObserveEventsTracedByPageCursorTracer() throws Exception
+    {
+        JfrPageCursorTracer pageCursorTracer = (JfrPageCursorTracer) JfrPageCursorTracerSupplier.INSTANCE.get();
+        JfrPageCacheTracer cacheTracer = new JfrPageCacheTracer();
+        pageCursorTracer.init( cacheTracer );
+
+        PinEvent pinEvent = pageCursorTracer.beginPin( true, 1L, new DummyPageSwapper( "dummy" ) );
+        pinEvent.hit();
+        pinEvent.done();
+
+        PinEvent pinEventForPageFault = pageCursorTracer.beginPin( true, 1L, new DummyPageSwapper( "dummy" ) );
+        {
+            PageFaultEvent pageFaultEvent = pinEventForPageFault.beginPageFault();
+            {
+                EvictionEvent evictionEvent = pageFaultEvent.beginEviction();
+                evictionEvent.close();
+            }
+            pageFaultEvent.done();
+        }
+        pinEventForPageFault.done();
+
+        assertEquals( 2, cacheTracer.pins() );
+        assertEquals( 2, cacheTracer.unpins() );
+        assertEquals( 1, cacheTracer.hits() );
+        assertEquals( 1, cacheTracer.faults() );
+        assertEquals( 1, cacheTracer.evictions() );
+    }
+}

--- a/tracers/src/test/java/org/neo4j/kernel/monitoring/tracing/jfr/JfrTracerFactoryTest.java
+++ b/tracers/src/test/java/org/neo4j/kernel/monitoring/tracing/jfr/JfrTracerFactoryTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.monitoring.tracing.jfr;
+
+import org.junit.Test;
+
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
+import org.neo4j.io.pagecache.tracing.jfr.JfrPageCacheTracer;
+import org.neo4j.io.pagecache.tracing.jfr.JfrPageCursorTracerSupplier;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class JfrTracerFactoryTest
+{
+    @Test
+    public void createPageCacheTracer() throws Exception
+    {
+        PageCacheTracer pageCacheTracer =
+                getTracerFactory().createPageCacheTracer( getMonitors(), getJobScheduler() );
+        assertThat( pageCacheTracer, instanceOf( JfrPageCacheTracer.class ) );
+    }
+
+    @Test
+    public void createPageCursorTracerSupplier() throws Exception
+    {
+        PageCursorTracerSupplier tracerSupplier =
+                getTracerFactory().createPageCursorTracerSupplier( getMonitors(), getJobScheduler() );
+        assertThat( tracerSupplier, instanceOf( JfrPageCursorTracerSupplier.class) );
+    }
+
+    private Monitors getMonitors()
+    {
+        return new Monitors();
+    }
+
+    private Neo4jJobScheduler getJobScheduler()
+    {
+        return new Neo4jJobScheduler();
+    }
+
+    private JfrTracerFactory getTracerFactory()
+    {
+        return new JfrTracerFactory();
+    }
+
+}


### PR DESCRIPTION
Update pin event to include hit metric.
Update documentation with correct configuration properties names.
Migrate to java 8.